### PR TITLE
protools2 v0.2.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: protools2
 Type: Package
 Title: A Set Of Tools For Proteomics And Phosphoproteomics Data Analysis
-Version: 0.2.10
+Version: 0.2.11
 Date: 2024-04-24
 Author: Pedro Rodriguez Cutillas, Irbaz I. Badshah
 Maintainer: Pedro Rodriguez Cutillas <p.cutillas@qmul.ac.uk>

--- a/R/normalize functions.R
+++ b/R/normalize functions.R
@@ -32,7 +32,7 @@ impute_na <- function(df.design, df.areas) {
 
 
 # Normalise phospho ----
-normalize_areas_return_ppindex_edit <- function(
+normalize_areas_return_ppindex <- function(
     pescal_output_file,
     delta_score_cut_off = 0  # if (fragpipe) {0} else {5}
 ) {
@@ -152,7 +152,7 @@ normalize_areas_return_ppindex_edit <- function(
 
 
 # Normalise total ----
-normalize_areas_return_protein_groups_edit <- function(
+normalize_areas_return_protein_groups <- function(
     pescal_output_file,
     mascot.score.cut.off = 50,  # if (fragpipe) {0} else {40}
     n.peptide.cut.off = 1
@@ -223,6 +223,7 @@ normalize_areas_return_protein_groups_edit <- function(
   )
 
   # Centred
+  # New improved NA imputation
   df.norm.log2.centered.na.imputed.new <- impute_na(
     df.design = df.design,
     df.areas = df.norm.log2.centered


### PR DESCRIPTION
# protools2 v0.2.11

- New `impute_na()` for 'normalisation functions.R':
  - `normalize_areas_return_ppindex()`
  - `normalize_areas_return_protein_groups()`
  - Replaces `NA` values in `df.areas` for the current condition with the row means calculated for each unique condition group, but if all values in the row for the current condition are `NA`, replace `NA` with the minimum value of the column - 1.
