### PR TITLE
protools2 v0.2.13

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: protools2
 Type: Package
 Title: A Set Of Tools For Proteomics And Phosphoproteomics Data Analysis
 Version: 0.2.13
-Date: 2024-05-13
+Date: 2025-04-15
 Authors@R: c(
     person("Pedro", "Cutillas", , "p.cutillas@qmul.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-3426-2274")),


### PR DESCRIPTION
# protools2 v0.2.13

## Changes
- `impute_na()`: imputes within groups; when all of a group are NA use `min` of dataset - 1; previously was `min` of file column - 1.
- normalise functions ('script_helpers.R', 'normalize functions.R'): makes use of updated `impute_na()`, corrected legacy imputation (non-grouped) with/without log.
- `enrichment.from.list()`: Fixes "cannot xtfrm data frames" error.